### PR TITLE
AWS中追加对参数endpoint_url的配置，用于支持自建ceph object gateway

### DIFF
--- a/jms_storage/aws.py
+++ b/jms_storage/aws.py
@@ -9,11 +9,13 @@ class aws:
         self.REGION = config.get("REGION", None)
         self.ACCESS_KEY = config.get("ACCESS_KEY", None)
         self.SECRET_KEY = config.get("SECRET_KEY", None)
+        self.ENDPOINT = config.get("ENDPOINT", None)
         if self.ACCESS_KEY and self.REGION and self.SECRET_KEY:
             self.client = boto3.client('s3',
                                        region_name=self.REGION,
                                        aws_access_key_id=self.ACCESS_KEY,
-                                       aws_secret_access_key=self.SECRET_KEY)
+                                       aws_secret_access_key=self.SECRET_KEY,
+                                       endpoint_url=self.ENDPOINT)
         else:
             self.client = boto3.client('s3')
 


### PR DESCRIPTION
本人搭建了一套ceph storage cluster和一个ceph object gateway用于保存录像数据，ceph的API与S3相兼容，正好可以使用本项目中的aws.py模块，但是该模块不支持自定义endpoint，追加endpoint_url参数后会支持自定义endpoint，且不影响AWS S3官方云存储功能。
参考文档：https://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.client