### PR TITLE
fix: 解决Azure判断文件总是不存在问题

### DIFF
--- a/jms_storage/azure.py
+++ b/jms_storage/azure.py
@@ -51,7 +51,7 @@ class AzureStorage(ObjectStorage):
             return False, e
 
     def exists(self, path):
-        resp = self.client.query_blob(name_starts_with=path)
+        resp = self.client.list_blobs(name_starts_with=path)
         return len(list(resp)) != 0
 
     def list_buckets(self):


### PR DESCRIPTION
fix: 解决Azure判断文件总是不存在问题