### PR TITLE
fix: Azure下载的文件多一层路径，导致录像无法观看

### DIFF
--- a/jms_storage/__init__.py
+++ b/jms_storage/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2018
 #
 
-__version__ = '0.0.53'
+__version__ = '0.0.54'
 
 from .ftp import FTPStorage
 from .oss import OSSStorage

--- a/jms_storage/azure.py
+++ b/jms_storage/azure.py
@@ -35,9 +35,8 @@ class AzureStorage(ObjectStorage):
     def download(self, src, target):
         try:
             blob_data = self.client.download_blob(blob=src)
-            filepath = os.path.join(target, blob_data.name)
-            os.makedirs(os.path.dirname(filepath), 0o755, exist_ok=True)
-            with open(filepath, 'wb') as writer:
+            os.makedirs(os.path.dirname(target), 0o755, exist_ok=True)
+            with open(target, 'wb') as writer:
                 writer.write(blob_data.readall())
             return True, None
         except Exception as e:


### PR DESCRIPTION
fix: Azure下载的文件多一层路径，导致录像无法观看